### PR TITLE
fix: rename smoke test cji task

### DIFF
--- a/pipelines/basic.yaml
+++ b/pipelines/basic.yaml
@@ -188,7 +188,7 @@ spec:
             value: "$(params.REVISION)"
           - name: pathInRepo
             value: tasks/deploy.yaml
-    - name: run-cji-smoke-test
+    - name: run-iqe-cji
       params:
         - name: BONFIRE_IMAGE
           value: "$(params.BONFIRE_IMAGE)"
@@ -238,4 +238,4 @@ spec:
           - name: revision
             value: "$(params.REVISION)"
           - name: pathInRepo
-            value: tasks/run-cji-smoke-test.yaml
+            value: tasks/run-iqe-cji.yaml

--- a/tasks/run-iqe-cji.yaml
+++ b/tasks/run-iqe-cji.yaml
@@ -1,7 +1,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
-  name: run-cji-smoke-test
+  name: run-iqe-cji
 spec:
   params:
     - name: BONFIRE_IMAGE
@@ -128,5 +128,5 @@ spec:
         echo "Connecting to the ephemeral namespace cluster"
         login.sh
 
-        echo "Deploying the IQE CJI smoke test"
+        echo "Deploying the IQE CJI test"
         deploy-iqe-cji.sh "$(params.NS)" "$(params.NS_REQUESTER)"


### PR DESCRIPTION
Renamed the iqe smoke test task to run-iqe-cji because not all CJI tests are smoke tests