### PR TITLE
Update the image after the rebase of cicd-tools

### DIFF
--- a/pipelines/basic.yaml
+++ b/pipelines/basic.yaml
@@ -17,7 +17,7 @@ spec:
     - name: BONFIRE_IMAGE
       type: string
       description: The container Bonfire image to use for the tekton tasks
-      default: quay.io/redhat-user-workloads/rhtap-migration-tenant/bonfire-cicd-tools/cicd-tools:build-3e00a-1713277065
+      default: quay.io/redhat-user-workloads/rhtap-migration-tenant/bonfire-cicd-tools/cicd-tools:fe1ebac02da86b0d0dfca5ee25857af801664110
     - name: SNAPSHOT
       type: string
       description: |

--- a/tasks/deploy.yaml
+++ b/tasks/deploy.yaml
@@ -8,7 +8,7 @@ spec:
     - name: BONFIRE_IMAGE
       type: string
       description: The container Bonfire image to use for the tekton tasks
-      default: quay.io/redhat-user-workloads/rhtap-migration-tenant/bonfire-cicd-tools/cicd-tools:build-3e00a-1713277065
+      default: quay.io/redhat-user-workloads/rhtap-migration-tenant/bonfire-cicd-tools/cicd-tools:fe1ebac02da86b0d0dfca5ee25857af801664110
     - name: SNAPSHOT
       type: string
       description: "AppStudio snapshot (see example above)"

--- a/tasks/reserve-namespace.yaml
+++ b/tasks/reserve-namespace.yaml
@@ -7,7 +7,7 @@ spec:
     - name: BONFIRE_IMAGE
       type: string
       description: The container Bonfire image to use for the tekton tasks
-      default: quay.io/redhat-user-workloads/rhtap-migration-tenant/bonfire-cicd-tools/cicd-tools:build-3e00a-1713277065
+      default: quay.io/redhat-user-workloads/rhtap-migration-tenant/bonfire-cicd-tools/cicd-tools:fe1ebac02da86b0d0dfca5ee25857af801664110
     - name: NS_REQUESTER
       type: string
       description: The name of the person/pipeline that requested the namespace

--- a/tasks/run-cji-smoke-test.yaml
+++ b/tasks/run-cji-smoke-test.yaml
@@ -7,7 +7,7 @@ spec:
     - name: BONFIRE_IMAGE
       type: string
       description: The container Bonfire image to use for the tekton tasks
-      default: quay.io/redhat-user-workloads/rhtap-migration-tenant/bonfire-cicd-tools/cicd-tools:build-3e00a-1713277065
+      default: quay.io/redhat-user-workloads/rhtap-migration-tenant/bonfire-cicd-tools/cicd-tools:fe1ebac02da86b0d0dfca5ee25857af801664110
     - name: EPHEMERAL_ENV_PROVIDER_SECRET
       type: string
       default: ephemeral-env-provider

--- a/tasks/teardown.yaml
+++ b/tasks/teardown.yaml
@@ -7,7 +7,7 @@ spec:
     - name: BONFIRE_IMAGE
       type: string
       description: The container Bonfire image to use for the tekton tasks
-      default: quay.io/redhat-user-workloads/rhtap-migration-tenant/bonfire-cicd-tools/cicd-tools:build-3e00a-1713277065
+      default: quay.io/redhat-user-workloads/rhtap-migration-tenant/bonfire-cicd-tools/cicd-tools:fe1ebac02da86b0d0dfca5ee25857af801664110
     - name: NS
       type: string
       description: Namespace name to release


### PR DESCRIPTION
The cicd-tools fork was rebased on the upstream repo. Updating to the image that was produced after the rebase.