### PR TITLE
Add Playwright container support to IQE CJI deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This repository has a Tekton pipeline, and its tasks, made based on the way the 
 
 For more information about how tests are currently handled, see this [repo](https://github.com/RedHatInsights/cicd-tools).
 
+
 ## How to use
 
 ### Prerequisites
@@ -79,6 +80,8 @@ spec:
       value: # "something" -- value to set for ENV_FOR_DYNACONF. Default is "clowder_smoke"
     - name: IQE_SELENIUM
       value: # Whether to run IQE pod with a selenium container. Default is "false"
+    - name: IQE_PLAYWRIGHT
+      value: # Whether to run IQE pod with a playwright container. Default is "false"
     - name: IQE_PARALLEL_ENABLED
       value: # Whether to run IQE in parallel mode. Default is "false"
     - name: IQE_PARALLEL_WORKER_COUNT

--- a/pipelines/basic.yaml
+++ b/pipelines/basic.yaml
@@ -116,6 +116,10 @@ spec:
       type: string
       description: "true -- whether to run IQE pod with a selenium container, default is false"
       default: "false"
+    - name: IQE_PLAYWRIGHT
+      type: string
+      description: "true -- whether to run IQE pod with a playwright container, default is false"
+      default: "false"
     - name: IQE_PARALLEL_ENABLED
       type: string
       description: "whether to run IQE with --parallel-enabled"
@@ -295,6 +299,8 @@ spec:
           value: "$(params.IQE_ENV_VARS)"
         - name: IQE_SELENIUM
           value: "$(params.IQE_SELENIUM)"
+        - name: IQE_PLAYWRIGHT
+          value: "$(params.IQE_PLAYWRIGHT)"
         - name: IQE_PARALLEL_ENABLED
           value: "$(params.IQE_PARALLEL_ENABLED)"
         - name: IQE_PARALLEL_WORKER_COUNT

--- a/pipelines/unit-integration-static-benchmark-iqe.yaml
+++ b/pipelines/unit-integration-static-benchmark-iqe.yaml
@@ -109,6 +109,10 @@ spec:
       type: string
       description: "true -- whether to run IQE pod with a selenium container, default is false"
       default: "false"
+    - name: IQE_PLAYWRIGHT
+      type: string
+      description: "true -- whether to run IQE pod with a playwright container, default is false"
+      default: "false"
     - name: IQE_PARALLEL_ENABLED
       type: string
       description: "whether to run IQE with --parallel-enabled"
@@ -274,6 +278,8 @@ spec:
           value: "$(params.IQE_ENV_VARS)"
         - name: IQE_SELENIUM
           value: "$(params.IQE_SELENIUM)"
+        - name: IQE_PLAYWRIGHT
+          value: "$(params.IQE_PLAYWRIGHT)"
         - name: IQE_PARALLEL_ENABLED
           value: "$(params.IQE_PARALLEL_ENABLED)"
         - name: IQE_PARALLEL_WORKER_COUNT

--- a/tasks/run-iqe-cji.yaml
+++ b/tasks/run-iqe-cji.yaml
@@ -71,6 +71,10 @@ spec:
       type: string
       description: "true -- whether to run IQE pod with a selenium container, default is false"
       default: "false"
+    - name: IQE_PLAYWRIGHT
+      type: string
+      description: "true -- whether to run IQE pod with a playwright container, default is false"
+      default: "false"
     - name: IQE_PARALLEL_ENABLED
       type: string
       description: "whether to run IQE with --parallel-enabled"
@@ -137,6 +141,8 @@ spec:
           value: $(params.IQE_ENV_VARS)
         - name: IQE_SELENIUM
           value: $(params.IQE_SELENIUM)
+        - name: IQE_PLAYWRIGHT
+          value: $(params.IQE_PLAYWRIGHT)
         - name: IQE_PARALLEL_ENABLED
           value: $(params.IQE_PARALLEL_ENABLED)
         - name: IQE_PARALLEL_WORKER_COUNT


### PR DESCRIPTION
Add IQE_PLAYWRIGHT parameter to enable Playwright container deployment in IQE test runs, following the same pattern as existing IQE_SELENIUM support.

Changes:
- tasks/run-iqe-cji.yaml: Add IQE_PLAYWRIGHT parameter and env var
- pipelines/basic.yaml: Add IQE_PLAYWRIGHT parameter and pass to task
- pipelines/unit-integration-static-benchmark-iqe.yaml: Add IQE_PLAYWRIGHT parameter and pass to iqe-tests task
- README.md: Document IQE_PLAYWRIGHT parameter in template

Users can now set IQE_PLAYWRIGHT: "true" in IntegrationTestScenario params to deploy IQE tests with Playwright container for UI testing.

Requires:
- cicd-tools update to pass --playwright flag to bonfire
- bonfire CLI --playwright flag support
- Clowder operator Playwright container creation support